### PR TITLE
Add injectGlobal in app.js

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Provider } from 'react-redux'
 import PropTypes from 'prop-types'
+import { injectGlobal } from 'styled-components'
 import Home from '../scenes/Home'
 
 const App = props => (
@@ -12,5 +13,19 @@ const App = props => (
 App.propTypes = {
   store: PropTypes.shape({}).isRequired,
 }
+
+/* eslint-disable no-unused-expressions */
+injectGlobal`
+  html,
+  body {
+    margin: 0;
+  }
+  html,
+  body,
+  #root {
+    width: 100%;
+    height: 100%;
+  }
+`
 
 export default App

--- a/src/index.html
+++ b/src/index.html
@@ -4,20 +4,9 @@
     <meta charset="UTF-8">
     <title>WebMadeira</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <style>
-      html,
-      body {
-        margin: 0;
-      }
-      html,
-      body,
-      #root {
-        height: 100%;
-      }
-    </style>
   </head>
-  <body style="height: 100%;">
-    <div id="root" style="height: 100%;"></div>
+  <body>
+    <div id="root"></div>
     <script src="bundle.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This MR is just to remove the inline style in `index.html` and use the `injectGlobal` method from `styled-components` instead.